### PR TITLE
alert on status code rates out of tolerated levels

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,7 +64,7 @@
         "no-bitwise": 0,
         "no-caller": 2,
         "no-catch-shadow": 0,
-        "no-cond-assign": 2,
+        "no-cond-assign": 0,
         "no-console": 0,
         "no-constant-condition": 0,
         "no-control-regex": 2,

--- a/index.js
+++ b/index.js
@@ -7,5 +7,12 @@ module.exports =
 		Heartbeat:   require('./lib/rules/heartbeat'),
 		Loadaverage: require('./lib/rules/load-average'),
 		Memory:      require('./lib/rules/memory'),
+		StatusRates: require('./lib/rules/status-rates'),
+	},
+	outputs:
+	{
+		Console:   require('./lib/outputs/console'),
+		PagerDuty: require('./lib/outputs/pagerduty'),
+		Slack:     require('./lib/outputs/slack'),
 	}
 };

--- a/lib/rules/reachability.js
+++ b/lib/rules/reachability.js
@@ -13,7 +13,8 @@ Memory.prototype._write = function(chunk, _, cb)
 	if (chunk.name !== 'reachability') return cb();
 
 	var incidentId = 'reachability.' + chunk.host + '.' + chunk.target;
-	if (chunk.value === 0) {
+	if (chunk.value === 0)
+	{
 		this.push({
 			id: incidentId,
 			name: 'reachability',
@@ -22,7 +23,8 @@ Memory.prototype._write = function(chunk, _, cb)
 			status: 'critical'
 		});
 	}
-	else {
+	else
+	{
 		this.push({
 			id: incidentId,
 			name: 'reachability',

--- a/lib/rules/status-rates.js
+++ b/lib/rules/status-rates.js
@@ -1,4 +1,5 @@
 var
+	assert        = require('assert'),
 	MovingAverage = require('moving-average'),
 	util          = require('util'),
 	Duplex        = require('stream').Duplex
@@ -10,10 +11,14 @@ var StatusCodeRates = module.exports = function StatusCodeRates(options)
 {
 	options = options || {};
 	this.rateAllowed = options.rateAllowed || 0.1;
+	assert(this.rateAllowed < 1, 'you really want a rate below 1 or this will never fire');
+
+	this.interval = options.interval || AVERAGE_INTERVAL;
 	this.alerts = {};
 	this.apps = {};
 
 	Duplex.call(this, { objectMode: true });
+
 };
 util.inherits(StatusCodeRates, Duplex);
 
@@ -29,10 +34,14 @@ StatusCodeRates.prototype._write = function(chunk, _, callback)
 	var matches = chunk.name.match(this.matcher);
 	if (!matches) return callback();
 
-	var app = matches[1];
+	var self = this,
+		app = matches[1];
 
 	if (!this.apps[app])
-		this.apps[app] = new AppRates(app);
+	{
+		this.apps[app] = new AppRates(this.interval);
+		setInterval(function() { self.checkRates(app); }, this.interval * 2);
+	}
 	var service = this.apps[app];
 
 	service.recordRequest(chunk);
@@ -45,12 +54,12 @@ StatusCodeRates.prototype.checkRates = function checkRates(app)
 	var service = this.apps[app];
 	var requests = service.requestRate.movingAverage();
 
-	var codes = Object.keys(service.movingAverages);
+	var codes = Object.keys(service.averages);
 	for (var i = 0; i < codes.length; i++)
 	{
 		var code = codes[i];
-		if (code === 200) continue; // we want these :)
-		var average = service.movingAverages[code].movingAverage();
+		if (code === '200') continue; // we want these :)
+		var average = service.averages[code].movingAverage();
 		var rate = average / requests;
 
 		if (rate > this.rateAllowed)
@@ -78,16 +87,17 @@ StatusCodeRates.prototype.checkRates = function checkRates(app)
 
 StatusCodeRates.prototype._read = function() {};
 
-var AppRates = function AppRates(name)
+var AppRates = function AppRates(interval)
 {
-	this.name = name;
+	this.interval = interval;
 	this.averages = {};
-	this.requestRate = new MovingAverage(AVERAGE_INTERVAL);
-	this.timer = setInterval(this.updateAverages.bind(this), AVERAGE_INTERVAL / 10);
+	this.requestRate = new MovingAverage(interval);
+	this.timer = setInterval(this.updateAverages.bind(this), interval / 10);
 
 	this.requests = 0;
 	this.statuses = {};
 };
+StatusCodeRates.AppRates  = AppRates; // I'd like to name this DogRates
 
 AppRates.prototype.name        = null;
 AppRates.prototype.averages    = null;
@@ -95,31 +105,34 @@ AppRates.prototype.requestRate = null;
 AppRates.prototype.timer       = null;
 AppRates.prototype.requests    = 0;
 AppRates.prototype.statuses    = {};
+AppRates.prototype.interval    = AVERAGE_INTERVAL;
 
 AppRates.prototype.recordRequest = function recordRequest(chunk)
 {
-	if (!this.movingAverages[chunk.statusCode])
+	if (!this.averages[chunk.statusCode])
 	{
-		this.movingAverages[chunk.statusCode] = new MovingAverage(AVERAGE_INTERVAL);
-		this.status[chunk.statusCode] = 0;
+		this.averages[chunk.statusCode] = new MovingAverage(this.interval);
+		this.statuses[chunk.statusCode] = 0;
 	}
 
-	this.status[chunk.statusCode]++;
+	this.statuses[chunk.statusCode]++;
 	this.requests++;
 };
 
-AppRates.prototype.updateAverages = function updateAverages(chunk)
+AppRates.prototype.updateAverages = function updateAverages()
 {
+	if (this.requests === 0) return;
 	var now = Date.now();
 
 	this.requestRate.push(now, this.requests);
-	this.requests = 0;
 
-	var codes = Object.keys(this.movingAverages);
+	var codes = Object.keys(this.averages);
 	for (var i = 0; i < codes.length; i++)
 	{
 		var code = codes[i];
-		this.movingAverages[code].push(now, this.statuses[code]);
+		this.averages[code].push(now, this.statuses[code]);
 		this.statuses[code] = 0;
 	}
+
+	this.requests = 0;
 };

--- a/lib/rules/statusrates.js
+++ b/lib/rules/statusrates.js
@@ -22,18 +22,6 @@ StatusCodeRates.prototype.rateAllowed = null;
 StatusCodeRates.prototype.alerts = null;
 StatusCodeRates.prototype.app = null;
 
-StatusCodeRates.prototype.resolve = function resolve(app, host, code, rate)
-{
-	this.push({
-		name:       'status-code-rates.' + app,
-		statusCode: code,
-		host:       host,
-		status:     'ok',
-		value:      rate
-	});
-	delete this.alerts[code];
-};
-
 StatusCodeRates.prototype._write = function(chunk, _, callback)
 {
 	if (!chunk.statusCode) return callback();
@@ -52,9 +40,9 @@ StatusCodeRates.prototype._write = function(chunk, _, callback)
 	callback();
 };
 
-StatusCodeRates.prototype.checkRates = function checkRates(appname)
+StatusCodeRates.prototype.checkRates = function checkRates(app)
 {
-	var service = this.apps[appname];
+	var service = this.apps[app];
 	var requests = service.requestRate.movingAverage();
 
 	var codes = Object.keys(service.movingAverages);
@@ -63,10 +51,27 @@ StatusCodeRates.prototype.checkRates = function checkRates(appname)
 		var code = codes[i];
 		if (code === 200) continue; // we want these :)
 		var average = service.movingAverages[code].movingAverage();
+		var rate = average / requests;
 
-		if ((average / requests) > this.rateAllowed)
+		if (rate > this.rateAllowed)
 		{
-			// TODO create alert
+			this.push({
+				name:       'status-code-rates.' + app,
+				statusCode: code,
+				status:     'critical', // TODO warning level & critical level
+				value:      rate
+			});
+			this.alerts[code] = rate;
+		}
+		else if (this.alerts[code])
+		{
+			this.push({
+				name:       'status-code-rates.' + app,
+				statusCode: code,
+				status:     'ok',
+				value:      rate
+			});
+			delete this.alerts[code];
 		}
 	}
 };

--- a/lib/rules/statusrates.js
+++ b/lib/rules/statusrates.js
@@ -1,0 +1,120 @@
+var
+	MovingAverage = require('moving-average'),
+	util          = require('util'),
+	Duplex        = require('stream').Duplex
+	;
+
+var AVERAGE_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+var StatusCodeRates = module.exports = function StatusCodeRates(options)
+{
+	options = options || {};
+	this.rateAllowed = options.rateAllowed || 0.1;
+	this.alerts = {};
+	this.apps = {};
+
+	Duplex.call(this, { objectMode: true });
+};
+util.inherits(StatusCodeRates, Duplex);
+
+StatusCodeRates.prototype.matcher = new RegExp('^(.*)\.response');
+StatusCodeRates.prototype.rateAllowed = null;
+StatusCodeRates.prototype.alerts = null;
+StatusCodeRates.prototype.app = null;
+
+StatusCodeRates.prototype.resolve = function resolve(app, host, code, rate)
+{
+	this.push({
+		name:       'status-code-rates.' + app,
+		statusCode: code,
+		host:       host,
+		status:     'ok',
+		value:      rate
+	});
+	delete this.alerts[code];
+};
+
+StatusCodeRates.prototype._write = function(chunk, _, callback)
+{
+	if (!chunk.statusCode) return callback();
+
+	var matches = chunk.name.match(this.matcher);
+	if (!matches) return callback();
+
+	var app = matches[1];
+
+	if (!this.apps[app])
+		this.apps[app] = new AppRates(app);
+	var service = this.apps[app];
+
+	service.recordRequest(chunk);
+
+	callback();
+};
+
+StatusCodeRates.prototype.checkRates = function checkRates(appname)
+{
+	var service = this.apps[appname];
+	var requests = service.requestRate.movingAverage();
+
+	var codes = Object.keys(service.movingAverages);
+	for (var i = 0; i < codes.length; i++)
+	{
+		var code = codes[i];
+		if (code === 200) continue; // we want these :)
+		var average = service.movingAverages[code].movingAverage();
+
+		if ((average / requests) > this.rateAllowed)
+		{
+			// TODO create alert
+		}
+	}
+};
+
+StatusCodeRates.prototype._read = function() {};
+
+var AppRates = function AppRates(name)
+{
+	this.name = name;
+	this.averages = {};
+	this.requestRate = new MovingAverage(AVERAGE_INTERVAL);
+	this.timer = setInterval(this.updateAverages.bind(this), AVERAGE_INTERVAL / 10);
+
+	this.requests = 0;
+	this.statuses = {};
+};
+
+AppRates.prototype.name        = null;
+AppRates.prototype.averages    = null;
+AppRates.prototype.requestRate = null;
+AppRates.prototype.timer       = null;
+AppRates.prototype.requests    = 0;
+AppRates.prototype.statuses    = {};
+
+AppRates.prototype.recordRequest = function recordRequest(chunk)
+{
+	if (!this.movingAverages[chunk.statusCode])
+	{
+		this.movingAverages[chunk.statusCode] = new MovingAverage(AVERAGE_INTERVAL);
+		this.status[chunk.statusCode] = 0;
+	}
+
+	this.status[chunk.statusCode]++;
+	this.requests++;
+};
+
+AppRates.prototype.updateAverages = function updateAverages(chunk)
+{
+	var now = Date.now();
+
+	this.requestRate.push(now, this.requests);
+	this.requests = 0;
+
+	var codes = Object.keys(this.movingAverages);
+	for (var i = 0; i < codes.length; i++)
+	{
+		var code = codes[i];
+		this.movingAverages[code].push(now, this.statuses[code]);
+		this.statuses[code] = 0;
+	}
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "json-stream": "~1.0.0",
     "lodash": "~4.13.1",
     "moment": "~2.14.1",
+    "moving-average": "~0.1.1",
     "redis": "~2.6.2",
     "request": "~2.73.0",
     "sinon": "~1.17.4",

--- a/test/05-status-rates.js
+++ b/test/05-status-rates.js
@@ -1,0 +1,125 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand = require('must'),
+	sinon = require('sinon'),
+	stream = require('stream'),
+	Rates  = require('../lib/rules/status-rates')
+	;
+
+describe('status rates', function()
+{
+	var rateChecker = new Rates({ interval: 500, rateAllowed: 0.5 });
+
+	it('can be constructed', function()
+	{
+		Rates.must.be.a.function();
+		var checker = new Rates();
+		checker.must.be.instanceof(stream.Duplex);
+	});
+
+	it('respects its options', function()
+	{
+		var checker = new Rates({ interval: 1000, rateAllowed: 0.5 });
+		checker.interval.must.equal(1000);
+		checker.rateAllowed.must.equal(0.5);
+
+		checker = new Rates();
+		checker.interval.must.equal(300000);
+		checker.rateAllowed.must.equal(0.1);
+	});
+
+	it('throws if you try to set a rate over 1', function()
+	{
+		function shouldThrow()
+		{
+			return new Rates({ interval: 1000, rateAllowed: 5 });
+		}
+
+		shouldThrow.must.throw(/rate/);
+	});
+
+	it('makes an app rate object for each app mentioned in a response metric', function(done)
+	{
+		var metric = { name: 'app.response', statusCode: 500 };
+		rateChecker.write(metric, function()
+		{
+			rateChecker.apps.must.have.property('app');
+			rateChecker.apps.app.must.be.instanceof(Rates.AppRates);
+			rateChecker.apps.app.interval.must.equal(rateChecker.interval);
+
+			rateChecker.write({ name: 'app2.response', statusCode: 200}, function()
+			{
+				rateChecker.apps.must.have.property('app2');
+				rateChecker.apps.app2.must.be.instanceof(Rates.AppRates);
+				done();
+			});
+		});
+	});
+
+	it('calls checkRates on a timer', function(done)
+	{
+		this.timeout(4000);
+		var spy = sinon.spy(rateChecker, 'checkRates');
+		setTimeout(function()
+		{
+			spy.called.must.be.true();
+			spy.calledWith('app').must.be.true();
+			spy.restore();
+			done();
+		}, 1000);
+	});
+
+	it('writes an alert when the rate exceeds the allowed rate', function(done)
+	{
+		this.timeout(4000);
+
+		for (var i = 0; i < 10; i++)
+			rateChecker.write({ name: 'app.response', statusCode: 500});
+
+		rateChecker.write({ name: 'app.response', statusCode: 500}, function()
+		{
+			setTimeout(function()
+			{
+				var alert = rateChecker.read();
+				alert.must.be.an.object();
+				alert.name.must.equal('status-code-rates.app');
+				alert.must.have.property('statusCode');
+				alert.statusCode.must.equal('500');
+				alert.must.have.property('status');
+				alert.status.must.match(/critical|warning/);
+				alert.must.have.property('value');
+				done();
+			}, 1000);
+		});
+	});
+
+	it('revokes the alert when the rate falls below the allowed rate', function(done)
+	{
+		this.timeout(5000);
+
+		for (var i = 0; i < 50; i++)
+			rateChecker.write({ name: 'app.response', statusCode: 200});
+
+		setTimeout(function()
+		{
+			var next = rateChecker.read(), alert;
+			while (next)
+			{
+				alert = next;
+				next = rateChecker.read();
+			}
+
+			alert.must.be.an.object();
+			alert.must.have.property('statusCode');
+			alert.statusCode.must.equal('500');
+			alert.must.have.property('status');
+			alert.status.must.equal('ok');
+			alert.must.have.property('value');
+			alert.value.must.be.below(0.5);
+			done();
+		}, 1000);
+	});
+
+});

--- a/test/05-status-rates.js
+++ b/test/05-status-rates.js
@@ -10,7 +10,7 @@ var
 
 describe('status rates', function()
 {
-	var rateChecker = new Rates({ interval: 500, rateAllowed: 0.5 });
+	var rateChecker = new Rates({ interval: 250, rateAllowed: 0.5 });
 
 	it('can be constructed', function()
 	{
@@ -68,7 +68,7 @@ describe('status rates', function()
 			spy.calledWith('app').must.be.true();
 			spy.restore();
 			done();
-		}, 1000);
+		}, 500);
 	});
 
 	it('writes an alert when the rate exceeds the allowed rate', function(done)
@@ -91,7 +91,7 @@ describe('status rates', function()
 				alert.status.must.match(/critical|warning/);
 				alert.must.have.property('value');
 				done();
-			}, 1000);
+			}, 500);
 		});
 	});
 
@@ -104,12 +104,9 @@ describe('status rates', function()
 
 		setTimeout(function()
 		{
-			var next = rateChecker.read(), alert;
-			while (next)
-			{
+			var next, alert;
+			while (next = rateChecker.read())
 				alert = next;
-				next = rateChecker.read();
-			}
 
 			alert.must.be.an.object();
 			alert.must.have.property('statusCode');
@@ -119,7 +116,7 @@ describe('status rates', function()
 			alert.must.have.property('value');
 			alert.value.must.be.below(0.5);
 			done();
-		}, 1000);
+		}, 500);
 	});
 
 });


### PR DESCRIPTION
Keep moving averages calculated by minute for every app we see, one for requests handled and one for each status code we see. Alert for every non-200 rate that rises above the allowed rate.

Features we might want that are not yet implemented here:

* alerting only on certain status codes
* varying rates by status code
* critical / warn thresholds